### PR TITLE
Fix for Circle Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@7.3.0
+  orb-tools: circleci/orb-tools@8.27.6
 
 workflows:
   version: 2
@@ -23,7 +23,6 @@ workflows:
           name: trigger-integration-dev
           requires:
             - orb-tools/publish-dev
-          ssh-fingerprints: f9:e0:22:5d:17:9e:50:03:60:c2:60:5a:1c:33:67:20
       - orb-tools/trigger-integration-workflow:
           filters:
             branches:
@@ -31,8 +30,7 @@ workflows:
           name: trigger-integration-master
           requires:
             - orb-tools/publish-dev
-          ssh-fingerprints: f9:e0:22:5d:17:9e:50:03:60:c2:60:5a:1c:33:67:20
-          tag: master
+
   cd:
     jobs:
       - orb-tools/dev-promote-prod:
@@ -52,12 +50,4 @@ workflows:
           name: dev-promote-minor
           orb-name: benjlevesque/pr-comment
           release: minor
-      - orb-tools/dev-promote-prod:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-major.*/
-          name: dev-promote-major
-          orb-name: benjlevesque/pr-comment
-          release: major
+

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Send Comment
           command: |
-            GH_LOGIN=$(curl -sS https://api.github.com/user\?access_token\=$GHI_TOKEN | jq '.login' --raw-output)
+            GH_LOGIN=$(curl -sS -H 'Authorization: token $GHI_TOKEN' https://api.github.com/user/repos | jq '.login' --raw-output)
             echo "Authenticated with $GH_LOGIN"
             PR_URL=<< parameters.pr >>
             PR_ID=${PR_URL##*/}

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Send Comment
           command: |
-            GH_LOGIN=$(curl -sS -H 'Authorization: token $GHI_TOKEN' https://api.github.com/user/repos | jq '.login' --raw-output)
+            GH_LOGIN=$(curl -sS https://api.github.com/user\?access_token\=$GHI_TOKEN | jq '.login' --raw-output)
             echo "Authenticated with $GH_LOGIN"
             PR_URL=<< parameters.pr >>
             PR_ID=${PR_URL##*/}


### PR DESCRIPTION
@benjlevesque

The effort to move to `orb-tools@9.x.x` is very high compared to merely using either the same `7.3.0` release or another `8.x.x` release. I would suggest using a previous release unless you have a very good reason to update to `9.x.x`. Version 9 is substantially different than prior releases. I was able to get nearly the entire pipeline working using `8.27.6`, however I ultimately could not test this completely because I can't write back to your repository.

Perhaps the work to moving to `9.x.x` could be left to a PR dedicated just to updating the circle config? My original request was merely to fix the deprecated github auth method.

Signed-off-by: mdgreenwald <mdgreenwald@gmail.com>