### PR TITLE
Use user endpoint to grab GH_LOGIN

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Send Comment
           command: |
-            GH_LOGIN=$(curl -sS -H 'Authorization: token $GHI_TOKEN' https://api.github.com/user/repos | jq '.login' --raw-output)
+            GH_LOGIN=$(curl -sS -H 'Authorization: token $GHI_TOKEN' https://api.github.com/user | jq '.login' --raw-output)
             echo "Authenticated with $GH_LOGIN"
             PR_URL=<< parameters.pr >>
             PR_ID=${PR_URL##*/}


### PR DESCRIPTION
Fixing the issue with GH_LOGIN being null and breaking the `maxComments` check by using the `/user` instead of `/user/repos`

Related to https://github.com/benjlevesque/circleci-orbs/issues/7