### PR TITLE
Fix github login authorization header

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Send Comment
           command: |
-            GH_LOGIN=$(curl -sS -H 'Authorization: token $GHI_TOKEN' https://api.github.com/user | jq '.login' --raw-output)
+            GH_LOGIN=$(curl -sS -H "Authorization: token $GHI_TOKEN" https://api.github.com/user | jq '.login' --raw-output)
             echo "Authenticated with $GH_LOGIN"
             PR_URL=<< parameters.pr >>
             PR_ID=${PR_URL##*/}


### PR DESCRIPTION
Authorization fails when using single quotes, double quotation marks fix the issue. (tested on macOS).